### PR TITLE
Switch clipboard syncing to use OSC 52 sequences

### DIFF
--- a/fish/functions/fish_clipboard_copy.fish
+++ b/fish/functions/fish_clipboard_copy.fish
@@ -2,6 +2,7 @@ function fish_clipboard_copy
     # Copy the current selection, or the entire commandline if that is empty.
     set -l cmdline (commandline --current-selection)
     test -n "$cmdline"; or set cmdline (commandline)
+    printf "\e]52;;%s\e\\" (echo $cmdline | base64 - | string trim --right) >/dev/tty
     if type -q pbcopy
         printf '%s\n' $cmdline | pbcopy
     else if type -q clip.exe

--- a/kak/autoload/clipboard.kak
+++ b/kak/autoload/clipboard.kak
@@ -1,12 +1,14 @@
-define-command -docstring "yank selection to Tmux and/or Windows clipboard" \
-clipboard-sync -hidden %{
-    evaluate-commands %sh{
-        if [ -n "$TMUX" ]; then
-            tmux set-buffer -- "$kak_selection"
-        fi
-        if command -v clip.exe >/dev/null; then
-            printf '%s\n' 'execute-keys <a-|>clip.exe<ret>'
-        fi
+define-command -docstring "yank selection to terminal clipboard using OSC 52" \
+clipboard-sync -hidden -override %{
+    nop %sh{
+        eval set -- "$kak_quoted_selections"
+        copy=$1
+        shift
+        for sel; do
+            copy=$(printf '%s\n%s' "$copy" "$sel")
+        done
+        encoded=$(printf %s "$copy" | base64 | tr -d '\n')
+        printf "\e]52;;%s\e\\" "$encoded" >/dev/tty
     }
 }
 map global normal <a-y> ': clipboard-sync<ret>'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -57,16 +57,16 @@ bind-key k select-pane -U
 bind-key l select-pane -R
 bind-key BSpace last-window
 
+# sync clipboard using OSC 52 sequences
+set-option -g set-clipboard on
+
 # tmux-resurrect
 set-option -g @resurrect-capture-pane-contents 'on'
 run-shell ~/.tmux/plugins/tmux-resurrect/resurrect.tmux
 
-if-shell 'which clip.exe' 'set-option -g @fingers-copy-command "clip.exe"'
+# tmux-fingers
 set-option -g @fingers-compact-hints 0
 run-shell ~/.tmux/plugins/tmux-fingers/tmux-fingers.tmux
-
-# yank to Windows clipboard with 'y'
-if-shell 'which clip.exe' 'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel clip.exe'
 
 # set terminal and window titles
 set-option -wg set-titles on

--- a/vim/autoload/misc.vim
+++ b/vim/autoload/misc.vim
@@ -70,3 +70,9 @@ function misc#hl_yank() abort
     redraw!
     call timer_start(500, {t_id -> clearmatches()})
 endfunction
+
+function misc#osc52_yank(text) abort
+    let encoded = substitute(system("base64 -", a:text), "\n$', "", "")
+    let seq = "\e]52;c;" . encoded . "\x07"
+    call writefile([seq], "/dev/tty", "b")
+endfunction

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -162,24 +162,15 @@ augroup HlYank
     autocmd TextYankPost * if v:event.operator ==# 'y' | call misc#hl_yank() | endif
 augroup END
 
-" WSL yank support
-let s:clip = '/mnt/c/Windows/System32/clip.exe'
-if executable(s:clip)
-    augroup WSLYank
-        autocmd!
-        autocmd TextYankPost * if v:event.operator ==# 'y' | call system(s:clip, @0) | endif
-    augroup END
-endif
+" Yank with OSC 52
+augroup ClipboardSync
+    autocmd!
+    autocmd TextYankPost * if v:event.operator ==# 'y' | call misc#osc52_yank(@0) | endif
+augroup END
 
-" Tmux mouse and yank support
-if exists('$TMUX')
-    if !has('nvim')
-        set ttymouse=sgr
-    endif
-    augroup TmuxYank
-        autocmd!
-        autocmd TextYankPost * if v:event.operator ==# 'y' | call system('tmux set-buffer -- ' .. shellescape(@0)) | endif
-    augroup END
+" Tmux mouse support
+if exists('$TMUX') && !has('nvim')
+    set ttymouse=sgr
 endif
 
 " Disable netrw


### PR DESCRIPTION
Instead of WSL and tmux-specific code to copy to system/tmux clipboard, use OSC 52 sequences. Supported by mintty, tmux, xterm (but not gnome-terminal yet?).

References:
- [set-clipboard](https://man.openbsd.org/OpenBSD-current/man1/tmux.1#set-clipboard) in tmux
- [AllowSetSelection option](https://mintty.github.io/mintty.1.html) for mintty
- Reference implementation for Vim in [vim-poweryank](https://github.com/haya14busa/vim-poweryank/blob/master/autoload/vital/_poweryank/Clipboard.vim)
- [hterm tool](https://chromium.googlesource.com/apps/libapps/+/HEAD/hterm/etc/osc52.sh)
- [VTE ticket](https://bugzilla.gnome.org/show_bug.cgi?id=795774)

Note that tmux no longer requires a special sequence as in the above references, but works fine with the regular OSC sequence.

Also, kakoune now can yank multiple selections to the clipboard, in which case they are concatenated with newlines.